### PR TITLE
Support partial objects as update request output

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "bluebird": "2.9.14",
     "debug": "^2.1.3",
     "deep-equal": "1.0.0",
-    "lodash-node": "3.6.0"
+    "lodash-node": "3.9.3"
   }
 }

--- a/src/model/model-ops.coffee
+++ b/src/model/model-ops.coffee
@@ -1,4 +1,8 @@
 Promise = require 'bluebird'
+_ = {
+  defaults: require 'lodash-node/modern/object/defaults'
+}
+
 jsonableEquality = require './jsonable-equality'
 
 objectSize = (o) -> Object.keys(o || {}).length
@@ -113,7 +117,7 @@ module.exports = (resource) ->
       null
 
     markAsSynced: (instance, data) ->
-      instance.__data = data
+      instance.__data = _.defaults(data, instance.__data)
       instance.__dirty = false
       instance.__changed = {}
       null

--- a/test/ModelInstanceSpec.coffee
+++ b/test/ModelInstanceSpec.coffee
@@ -301,6 +301,22 @@ describe "ag-data.model.instance", ->
               instance.save().then ->
                 instance.foo.should.equal 'qux'
 
+          it "retains current values if not set in update result", ->
+            model = buildModel mockResource {
+              fields:
+                foo: {}
+                bar: {}
+              find:
+                {}
+              update:
+                bar: 'baz'
+            }
+            model.find(1).then (instance) ->
+              instance.foo = 'qux'
+              instance.save().then ->
+                instance.foo.should.equal 'qux'
+                instance.bar.should.equal 'baz'
+
   describe "identity", ->
 
     it "can be accessed from .id", ->

--- a/test/ModelInstanceSpec.coffee
+++ b/test/ModelInstanceSpec.coffee
@@ -272,6 +272,35 @@ describe "ag-data.model.instance", ->
             instance.save().then ->
               resource.update.should.have.been.calledWith 1, {}
 
+        describe "state synchronization", ->
+
+          it "accepts an updated value different to what was sent", ->
+            model = buildModel mockResource {
+              fields:
+                foo: {}
+              find:
+                foo: 'bar'
+              update:
+                foo: 'baz'
+            }
+            model.find(1).then (instance) ->
+              instance.foo = 'qux'
+              instance.save().then ->
+                instance.foo.should.equal 'baz'
+
+          it "accepts an updated value for a field that was not set", ->
+            model = buildModel mockResource {
+              fields:
+                foo: {}
+              find:
+                {}
+              update:
+                foo: 'qux'
+            }
+            model.find(1).then (instance) ->
+              instance.save().then ->
+                instance.foo.should.equal 'qux'
+
   describe "identity", ->
 
     it "can be accessed from .id", ->


### PR DESCRIPTION
Allows resource endpoints to only return a partial object upon an update request. Previously, missing data on an update would yield a model instance with only the partial data present. Now the incoming partial data is merged to the current state.